### PR TITLE
Added support for 500, 502, 503 and 504 error codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.14.2] - 2021-06-21
+- Added support for 500, 502, 503 and 504 error codes.
+
 ## [0.14.1] - 2021-04-28
 - Added query parameter paymentMethodPreferred to init payment endpoint
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ $response = $kevinClient->auth()->receiveTokenContent($attr);
 
 ### 2.1 Initiate bank payment
 
+:exclamation: _Take a note that the example below is for the v0.3 only. The v0.1 and v0.2 requires a slightly different body._
+
 ```
 $attr = [
     'Redirect-URL' => 'https://redirect.getkevin.eu/payment.html',

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ $response = $kevinClient->payment()->getPaymentRefunds($paymentId);
 
 ## Support
 
-Email: support@getkevin.eu
+Email: help@kevin.eu
 
 ## License
 

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -193,6 +193,9 @@ trait UtilityTrait
             case 500:
                 $response = ['error' => ['code' => 500, 'name' => 'Exception', 'description' => 'Internal server error.'], 'data' => []];
                 break;
+            case 502:
+                $response = ['error' => ['code' => 502, 'name' => 'Exception', 'description' => 'Bad Gateway.'], 'data' => []];
+                break;
             case 503:
                 $response = ['error' => ['code' => 503, 'name' => 'Exception', 'description' => 'Service unavailable.'], 'data' => []];
                 break;

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -177,6 +177,8 @@ trait UtilityTrait
      */
     private function buildResponse($response)
     {
+        $is_error = true;
+
         switch ($response['code']) {
             case 200:
                 $response = json_decode($response['data'], true);
@@ -184,16 +186,22 @@ trait UtilityTrait
                 break;
             case 400:
                 $response = json_decode($response['data'], true);
-                $is_error = true;
                 break;
             case 401:
-                $response = ['error' => ['code' => -1, 'name' => 'Unauthorized', 'description' => 'Unauthorized'], 'data' => []];
-                $is_error = true;
+                $response = ['error' => ['code' => 401, 'name' => 'Unauthorized', 'description' => 'Unauthorized'], 'data' => []];
+                break;
+            case 500:
+                $response = ['error' => ['code' => 500, 'name' => 'Exception', 'description' => 'Internal server error.'], 'data' => []];
+                break;
+            case 503:
+                $response = ['error' => ['code' => 503, 'name' => 'Exception', 'description' => 'Service unavailable.'], 'data' => []];
+                break;
+            case 504:
+                $response = ['error' => ['code' => 504, 'name' => 'Exception', 'description' => 'Gateway timeout.'], 'data' => []];
                 break;
             default:
                 // Should not happen
                 $response = ['error' => ['code' => -1, 'name' => 'Exception', 'description' => 'Unknown error.'], 'data' => []];
-                $is_error = true;
         }
 
         if ($is_error) {


### PR DESCRIPTION
Although these errors can occur rarely, the idea came after one customer were getting 503 error code, but it was displayed as -1 code.

The error codes were added following the same format in the code.

Plus, in my opinion, the documentation need to be clarified that all examples are for the v0.3 since, for instance, the bank payment initiation for the v0.1 and v0.2 requires a slightly different body.