### PR TITLE
TS-167: Option to pass webhook url on authentication and edit base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.15.1] - 2021-11-29
+- Support for `Webhook-URL` header on authentication
+- New `domain` option to switch between environments easily.
+
 ## [0.15.0] - 2021-11-28
 - Added support for Account Information Service (AIS)
 - Fixes a bug when multiple authentication scopes could not be supplied

--- a/src/AuthTrait.php
+++ b/src/AuthTrait.php
@@ -88,6 +88,10 @@ trait AuthTrait
             $data[] = 'Redirect-URL: ' . $attr['Redirect-URL'];
         }
 
+        if (isset($attr['Webhook-URL'])) {
+            $data[] = 'Webhook-URL: ' . $attr['Webhook-URL'];
+        }
+
         return $data;
     }
 

--- a/src/AuthTrait.php
+++ b/src/AuthTrait.php
@@ -88,8 +88,10 @@ trait AuthTrait
             $data[] = 'Redirect-URL: ' . $attr['Redirect-URL'];
         }
 
-        if (isset($attr['Webhook-URL'])) {
-            $data[] = 'Webhook-URL: ' . $attr['Webhook-URL'];
+        if ($this->getOption('version') == '0.3') {
+            if (isset($attr['Webhook-URL'])) {
+                $data[] = 'Webhook-URL: ' . $attr['Webhook-URL'];
+            }
         }
 
         return $data;

--- a/src/EndpointInterface.php
+++ b/src/EndpointInterface.php
@@ -12,9 +12,9 @@ interface EndpointInterface
      */
 
     const SERVICE_NAME = '/platform';
-    const BASE_URL_V01 = self::SERVICE_NAME . '/v0.1';
-    const BASE_URL_V02 = self::SERVICE_NAME . '/v0.2';
-    const BASE_URL_V03 = self::SERVICE_NAME . '/v0.3';
+    const BASE_PATH_V01 = self::SERVICE_NAME . '/v0.1';
+    const BASE_PATH_V02 = self::SERVICE_NAME . '/v0.2';
+    const BASE_PATH_V03 = self::SERVICE_NAME . '/v0.3';
 
     /**
      * List of Auth related endpoints.

--- a/src/EndpointInterface.php
+++ b/src/EndpointInterface.php
@@ -10,10 +10,11 @@ interface EndpointInterface
     /**
      * Base URL used for sending API calls.
      */
-    const BASE_URL = 'https://api.kevin.eu/platform';
-    const BASE_URL_V01 = self::BASE_URL . '/v0.1';
-    const BASE_URL_V02 = self::BASE_URL . '/v0.2';
-    const BASE_URL_V03 = self::BASE_URL . '/v0.3';
+
+    const SERVICE_NAME = '/platform';
+    const BASE_URL_V01 = self::SERVICE_NAME . '/v0.1';
+    const BASE_URL_V02 = self::SERVICE_NAME . '/v0.2';
+    const BASE_URL_V03 = self::SERVICE_NAME . '/v0.3';
 
     /**
      * List of Auth related endpoints.

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -423,7 +423,7 @@ trait UtilityTrait
                 $base_url = $scheme . $domain . self::BASE_PATH_V03;
                 break;
             default:
-                $base_url = $scheme . $domain . self::BASE_PATH_V02;
+                $base_url = $scheme . $domain . self::BASE_PATH_V03;
         }
 
         return $base_url;

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -414,16 +414,16 @@ trait UtilityTrait
 
         switch ($version) {
             case '0.1':
-                $base_url = $scheme . $domain . self::BASE_URL_V01;
+                $base_url = $scheme . $domain . self::BASE_PATH_V01;
                 break;
             case '0.2':
-                $base_url = $scheme . $domain . self::BASE_URL_V02;
+                $base_url = $scheme . $domain . self::BASE_PATH_V02;
                 break;
             case '0.3':
-                $base_url = $scheme . $domain . self::BASE_URL_V03;
+                $base_url = $scheme . $domain . self::BASE_PATH_V03;
                 break;
             default:
-                $base_url = $scheme . $domain . self::BASE_URL_V02;
+                $base_url = $scheme . $domain . self::BASE_PATH_V02;
         }
 
         return $base_url;

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -329,7 +329,8 @@ trait UtilityTrait
     {
         $data = [
             'error' => 'exception',
-            'version' => '0.3'
+            'version' => '0.3',
+            'domain' => 'api.kevin.eu'
         ];
 
         $optionError = ['exception', 'array'];
@@ -345,6 +346,11 @@ trait UtilityTrait
         $optionLanguages = ['en', 'lt', 'lv', 'et', 'fi', 'se', 'ru'];
         if (isset($options['lang']) && in_array($options['lang'], $optionLanguages)) {
             $data['lang'] = $options['lang'];
+        }
+
+        $optionDomain = ['api-kevin.eu', 'api-sandbox.kevin.eu', 'api-dev.kevin.eu'];
+        if (isset($options['domain']) && in_array($options['domain'], $optionDomain)) {
+            $data['domain'] = $options['domain'];
         }
 
         if (isset($options['pluginVersion'])) {
@@ -403,19 +409,21 @@ trait UtilityTrait
     private function getBaseUrl()
     {
         $version = $this->getOption('version');
+        $domain = $this->getOption('domain');
+        $scheme = 'https://';
 
         switch ($version) {
             case '0.1':
-                $base_url = self::BASE_URL_V01;
+                $base_url = $scheme . $domain . self::BASE_URL_V01;
                 break;
             case '0.2':
-                $base_url = self::BASE_URL_V02;
+                $base_url = $scheme . $domain . self::BASE_URL_V02;
                 break;
             case '0.3':
-                $base_url = self::BASE_URL_V03;
+                $base_url = $scheme . $domain . self::BASE_URL_V03;
                 break;
             default:
-                $base_url = self::BASE_URL_V02;
+                $base_url = $scheme . $domain . self::BASE_URL_V02;
         }
 
         return $base_url;


### PR DESCRIPTION
1. `Webhook-URL` header is now required for a new `payments_pos` scope: https://docs.kevin.eu/public/platform/v0.3#operation/startAuth
2. Made a new `domain` option to switch between environments easily without any code changes.