### PR TITLE
TS-366: Fix card linking support

### DIFF
--- a/src/AuthTrait.php
+++ b/src/AuthTrait.php
@@ -66,6 +66,10 @@ trait AuthTrait
         if (isset($attr['email'])) {
             $data['email'] = strval($attr['email']);
         }
+        
+        if (isset($attr['cardMethod'])) {
+            $data['cardMethod'] = [];
+        }
 
         return $data;
     }


### PR DESCRIPTION
Till now it was not possible to link payment card, body attribute cardMethod was ignored. This fix enables that.