### PR TITLE
de-hardcode port and url scheme

### DIFF
--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -105,13 +105,15 @@ trait UtilityTrait
         $parsed = parse_url($url);
 
         $host = $parsed['host'];
+        $prefix = '';
+        $port = 80;
+
         if ($parsed['scheme'] === 'https') {
             $prefix = 'ssl://';
             $port = 443;
-        } else {
-            $prefix = '';
-            $port = 80;
         }
+
+        $port = isset($this->options['port']) ? $this->options['port'] : $port;
 
         if (preg_match('/(%[0-9A-F]{2})/', $jsonData)) {
             $jsonData = urldecode($jsonData);
@@ -333,6 +335,8 @@ trait UtilityTrait
             'error' => 'exception',
             'version' => '0.3',
             'domain' => 'api.kevin.eu',
+            'port' => null,
+            'scheme' => 'https',
         ];
 
         $optionError = ['exception', 'array'];
@@ -364,6 +368,13 @@ trait UtilityTrait
             $data['pluginPlatformVersion'] = $options['pluginPlatformVersion'];
         }
 
+        if (isset($options['port']) && 1 <= $options['port'] && $options['port'] <= 65535) {
+            $data['port'] = (int)$options['port'];
+        }
+
+        if (isset($options['scheme']) && in_array($options['scheme'], ['https', 'http'], true)) {
+            $data['scheme'] = $options['scheme'];
+        }
         return $data;
     }
 
@@ -408,7 +419,7 @@ trait UtilityTrait
     {
         $version = $this->getOption('version');
         $domain = $this->getOption('domain');
-        $scheme = 'https://';
+        $scheme = $this->getOption('scheme').'://';
 
         switch ($version) {
             case '0.1':

--- a/src/UtilityTrait.php
+++ b/src/UtilityTrait.php
@@ -368,13 +368,14 @@ trait UtilityTrait
             $data['pluginPlatformVersion'] = $options['pluginPlatformVersion'];
         }
 
-        if (isset($options['port']) && 1 <= $options['port'] && $options['port'] <= 65535) {
-            $data['port'] = (int)$options['port'];
+        if (isset($options['port']) && $options['port'] >= 1 && $options['port'] <= 65535) {
+            $data['port'] = (int) $options['port'];
         }
 
         if (isset($options['scheme']) && in_array($options['scheme'], ['https', 'http'], true)) {
             $data['scheme'] = $options['scheme'];
         }
+
         return $data;
     }
 


### PR DESCRIPTION
The application that requires this package may have automatic pipeline tests that simulate the kevin environment. 
Using the existing kevin sandbox domain is not an option because the pipeline will execute on every commit.
The domain themselves are hardcoded in UtilityTrait::processOptionsAttributes() but that can be resolved  
when building the virtual environment for the tests.
However, the ports and URI scheme cannot be configured because they are hardcoded.

This PR adds the keys "scheme" and "port" to the options array property, while keeping the existing functionality as it is.